### PR TITLE
use googles caja lib to escape XSS attempts

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
 
   "dependencies": {
     "coffee-script" : "latest",
-    "express" : "latest"
+    "express" : "latest",
+    "sanitizer": "latest"
   }
 }

--- a/server.coffee
+++ b/server.coffee
@@ -1,4 +1,5 @@
 express = require 'express'
+sanitizer = require 'sanitizer'
 
 template = (message, subtitle) -> '
 <html>
@@ -11,8 +12,8 @@ template = (message, subtitle) -> '
   <body style="margin-top:40px;">
     <div class="container">
       <div id="view-10" view=""><div class="hero-unit">
-        <h1>'+message+'</h1>
-        <p><em>'+subtitle+'</em></p>
+        <h1>'+sanitizer.escape(message)+'</h1>
+        <p><em>'+sanitizer.escape(subtitle)+'</em></p>
         </div>
       </div>
     </div>


### PR DESCRIPTION
@tomcully @xenph @maetl 

could also use use sanitize so xss attempts are stripped, but leaves other tags (eg `<i>`)?
e.g.
`http://10.1.3.54:5000/you/aaa%3Cscript%3Ealert%281%29%3C%2Fscript%3E%3Ci%3Exxx%3C%2Fi%3E/c`
displays

```
<div class="hero-unit">
        <h1>Fuck you, aaa<i>xxx</i>.</h1>
        <p><em>- c</em></p>
</div>
```
