### PR TITLE
fixes version in index.html

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -11,7 +11,7 @@
         <h1>FOAAS</h1>
         <h2>Fuck Off As A Service</h2>
         <p>Please see README for use.</p>
-        <p><em>v0.0.1</em></p>
+        <p><em>v0.0.2</em></p>
       </div>
     </div>
     <div class="container">


### PR DESCRIPTION
According to https://github.com/xenph/foaas, the
edge FOAAS is available in version 0.0.2, but the
current index.html file still contains the old
version number.
