### PR TITLE
token #{req.params.from} was twice in "fascinating/"

### DIFF
--- a/server.coffee
+++ b/server.coffee
@@ -134,7 +134,7 @@ app.get '/flying/:from', (req, res) ->
   dooutput(res, message, subtitle)
 
 app.get '/fascinating/:from', (req, res) ->
-  message = "Fascinating story, in what chapter do you shut the fuck up? - #{req.params.from}."
+  message = "Fascinating story, in what chapter do you shut the fuck up?"
   subtitle = "- #{req.params.from}"
   dooutput(res, message, subtitle)
 


### PR DESCRIPTION
The new "fascinating/:from" endpoint used the :from token twice in the reply.  Here is one suggestion to fix it.
