### PR TITLE
Change URL for Ruby client

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ API clients are available in a number of languages:
 | Language | Name           | Info |
 |:---------|:---------------|:-----|
 | JS/Node  | `foaas-client` | https://www.npmjs.org/package/foaas-client |
-| Ruby     | `foaas-client` | https://rubygems.org/gems/foaas-client/versions/0.0.0 |
+| Ruby     | `foaas-client` | https://github.com/petedmarsh/foaas-client |
 | PHP      | `foaas-php`    | https://github.com/klaude/foaas-php |
 | Python   | `foaas-python` | https://github.com/dmpayton/foaas-python |
 | R        | `rfoaas`       | https://github.com/eddelbuettel/rfoaas |


### PR DESCRIPTION
I noticed that the URL for the Ruby client pointed to its RubyGems page instead of its GitHub page so I thought I would change it :-)
