### PR TITLE
Adding JSONP support

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -24,7 +24,12 @@
 
         <ul>
           <li>text/plain - Content will be returned as a plain string.</li>
-          <li>application/json - Content will be returned as a JSON object <code>{ message: 'message', subtitle: 'subtitle' }</code></li>
+          <li>
+            application/json - Content will be returned as a JSON object <code>{ message: 'message', subtitle: 'subtitle' }</code>
+            <ul>
+              <li>Supports jsonp by including <code>?callback=?</code></li>
+            </ul>
+          </li>
           <li>text/html - Content will be returned as an HTML page with a twitter bootstrap hero unit, containing the message and the subtitle.</li>
           <li>application/xml - Content will be returned as a XML document.</li>
         </ul>

--- a/server.coffee
+++ b/server.coffee
@@ -39,7 +39,7 @@ dooutput = (res, message, subtitle) ->
     "text/plain": ->
       res.send "#{message} #{subtitle}"
     "application/json": ->
-      res.send JSON.stringify { message: message, subtitle: subtitle }
+      res.jsonp { message: message, subtitle: subtitle }
     "text/html": ->
       res.send templateHTML(message,subtitle)
     "application/xml": ->
@@ -71,7 +71,7 @@ app.get '/version', (req, res) ->
     "text/plain": ->
       res.send "FOAAS Version #{helpers.VERSION}"
     "application/json": ->
-      res.send JSON.stringify { version: helpers.VERSION }
+      res.json { version: helpers.VERSION }
     "text/html": ->
       res.send templateHTML("Version #{helpers.VERSION}",'FOAAS')
     "application/xml": ->


### PR DESCRIPTION
Updating the JSON endpoints to use [res.jsonp](http://expressjs.com/api.html#res.jsonp) instead of `res.send JSON.stringify`
