### PR TITLE
Fixed typo and missing slash.

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -149,7 +149,7 @@
             </tr>
 
             <tr>
-                <td>madison/:name/:from</td>
+                <td>/madison/:name/:from</td>
                 <td>Will return content of the form 'What you've just said is one of the most insanely idiotic things I have ever heard, :name. At no point in your rambling, incoherent response were you even close to anything that could be considered a rational thought. Everyone in this room is now dumber for having listened to it. I award you no points :name, and may God have mercy on your soul. -  :from'</td>
             </tr>
 
@@ -185,7 +185,7 @@
 
             <tr>
                 <td>/because/:from</td>
-                <td>Will return content of the form 'Why? Beacuse Fuck you, that's why. - :from'. </td>
+                <td>Will return content of the form 'Why? Because Fuck you, that's why. - :from'. </td>
             </tr>
             
             <tr>


### PR DESCRIPTION
Fixed typo in resource /because and added leading slash to the /madison
resource.