### PR TITLE
Making the example links clickable in the description

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -62,77 +62,78 @@
 
             <tr>
                 <td>/off/:name/:from</td>
-                <td>Will return content of the form 'Fuck off, :name. - :from', e.g. /off/Tom/Chris will return 'Fuck off, Tom - Chris'</td>
+                <td>Will return content of the form 'Fuck off, :name. - :from', e.g. <a href='/off/Tom/Chris' target='_blank'>/off/Tom/Chris</a> will return 'Fuck off, Tom - Chris'</td>
             </tr>
 
             <tr>
                 <td>/you/:name/:from</td>
-                <td>Will return content of the form 'Fuck you, :name. - :from', e.g. /you/Tom/Chris will return 'Fuck you, Tom - Chris'</td>
+                <td>Will return content of the form 'Fuck you, :name. - :from', e.g. <a href='/you/Tom/Chris' target='_blank'>/you/Tom/Chris</a> will return 'Fuck you, Tom - Chris'</td>
             </tr>
 
             <tr>
                 <td>/this/:from</td>
-                <td>Will return content of the form 'Fuck this - :from', e.g. /this/Chris will return 'Fuck this. - Chris'</td>
+                <td>Will return content of the form 'Fuck this - :from', e.g. <a href='/this/Chris' target='_blank'>/this/Chris</a> will return 'Fuck this. - Chris'</td>
             </tr>
 
             <tr>
                 <td>/that/:from</td>
-                <td>Will return content of the form 'Fuck that. - :from', e.g. /that/Chris will return 'Fuck that. - Chris'</td>
+                <td>Will return content of the form 'Fuck that. - :from', e.g. <a href='/that/Chris' target='_blank'>/that/Chris</a> will return 'Fuck that. - Chris'</td>
             </tr>
 
             <tr>
                 <td>/everything/:from</td>
-                <td>Will return content of the form 'Fuck everything. - :from', e.g. /everything/Chris will return 'Fuck everything. - Chris'</td>
+                <td>Will return content of the form 'Fuck everything. - :from', e.g. <a href='/everything/Chris' target='_blank'>/everything/Chris</a> will return 'Fuck everything. - Chris'</td>
             </tr>
 
             <tr>
                 <td>/everyone/:from</td>
-                <td>Will return content of the form 'Everyone can go and fuck off. - :name', e.g. /everyone/Tom will return 'Everyone can go and fuck off. - Tom'</td>
+                <td>Will return content of the form 'Everyone can go and fuck off. - :name', e.g. <a href='/everyone/Tom' target='_blank'>/everyone/Tom</a> will return 'Everyone can go and fuck off. - Tom'</td>
             </tr>
 
             <tr>
                 <td>/donut/:name/:from</td>
-                <td>Will return content of the form ':name, go and take a flying fuck at a rolling donut. - :from', e.g. /donut/Tom/Chris will return 'Tom, go and take a flying fuck at a rolling donut. - Chris'</td>
+                <td>Will return content of the form ':name, go and take a flying fuck at a rolling donut. - :from', e.g. <a href='/donut/Tom/Chris' target='_blank'>/donut/Tom/Chris</a> will return 'Tom, go and take a flying fuck at a rolling donut. - Chris'</td>
             </tr>
 
             <tr>
                 <td>/shakespeare/:name/:from</td>
-                <td>Will return content of the form ':name, Thou clay-brained guts, thou knotty-pated fool, thou whoreson obscene greasy tallow-catch! - :from', e.g. /shakespeare/Falstaff/Prince%20Henry will return 'Falstaff, Thou clay-brained guts, thou knotty-pated fool, thou whoreson obscene greasy tallow-catch! - Prince Henry</td>
+                <td>Will return content of the form ':name, Thou clay-brained guts, thou knotty-pated fool, thou whoreson obscene greasy tallow-catch! - :from', e.g. <a href='/shakespeare/Falstaff/Prince%20Henry' target='_blank'>/shakespeare/Falstaff/Prince%20Henry</a> will return 'Falstaff, Thou clay-brained guts, thou knotty-pated fool, thou whoreson obscene greasy tallow-catch! - Prince Henry</td>
             </tr>
 
             <tr>
                 <td>/linus/:name/:from</td>
-                <td>Will return content of the form ':name, there aren't enough swear-words in the English language, so now I'll have to call you perkeleen vittupää just to express my disgust and frustration with this crap. - :from'. </td>
+                <td>Will return content of the form ':name, there aren't enough swear-words in the English language, so now I'll have to call you perkeleen vittupää just to express my disgust and frustration with this crap. - :from'.
+                  e.g. <a href='/linus/Tom/Chris'>/linus/Tom/Chris</a></td>
             </tr>
 
             <tr>
                 <td>/king/:name/:from</td>
-                <td>Will return content of the form 'Oh fuck off, just really fuck off you total dickface. Christ :name, you are fucking thick. - :from'. </td>
+                <td>Will return content of the form 'Oh fuck off, just really fuck off you total dickface. Christ :name, you are fucking thick. - :from'. e.g. <a href='/king/Tom/Chris' target='_blank'>/king/Tom/Chris</a> </td>
             </tr>
 
             <tr>
                 <td>/pink/:from</td>
-                <td>Will return content of the form 'Well, Fuck me pink. - :from'. </td>
+                <td>Will return content of the form 'Well, Fuck me pink. - :from'. e.g. <a href='/pink/Tom' target='_blank'>/pink/Tom</a></td>
             </tr>
 
             <tr>
                 <td>/life/:from</td>
-                <td>Will return content of the form 'Fuck my life. - :from', e.g. /life/Phil will return 'Fuck my life. - Phil'</td>
+                <td>Will return content of the form 'Fuck my life. - :from', e.g. <a href='/life/Phil' target='_blank'>/life/Phil</a> will return 'Fuck my life. - Phil'. </td>
             </tr>
 
             <tr>
                 <td>/chainsaw/:name/:from</td>
-                <td>Will return content of the form 'Fuck me gently with a chainsaw, :name. Do I look like Mother Teresa? - :from', e.g. /chainsaw/Chris/Heather will return 'Fuck me gently with a chainsaw, Chris. Do I look like Mother Teresa? - Heather'.</td>
+                <td>Will return content of the form 'Fuck me gently with a chainsaw, :name. Do I look like Mother Teresa? - :from', e.g. <a href='/chainsaw/Chris/Heather' target='_blank'>/chainsaw/Chris/Heather</a> will return 'Fuck me gently with a chainsaw, Chris. Do I look like Mother Teresa? - Heather'.</td>
             </tr>
 
             <tr>
                 <td>/outside/:name/:from</td>
-                <td>Will return content of the form ':name, why don't you go outside and play hide-and-go-fuck-yourself? - :from', e.g. /outside/BigBrother/TheWorld will return 'BigBrother, why don't you go outside and play hide-and-go-fuck-yourself? - TheWorld'.</td>
+                <td>Will return content of the form ':name, why don't you go outside and play hide-and-go-fuck-yourself? - :from', e.g. <a href='/outside/BigBrother/TheWorld' target='_blank'>/outside/BigBrother/TheWorld</a> will return 'BigBrother, why don't you go outside and play hide-and-go-fuck-yourself? - TheWorld'.</td>
             </tr>
 
             <tr>
                 <td>/:thing/:from</td>
-                <td>Will return content of the form 'Fuck :thing. - :from', e.g. /pineapples/%E2%99%A5%20Chris will return 'Fuck pineapples. - ♥ Chris' </td>
+                <td>Will return content of the form 'Fuck :thing. - :from', e.g. <a href='/pineapples/%E2%99%A5%20Chris' target='_blank'>/pineapples/%E2%99%A5%20Chris</a> will return 'Fuck pineapples. - ♥ Chris' </td>
             </tr>
 
             <tr>
@@ -142,7 +143,7 @@
 
             <tr>
                 <td>/flying/:from</td>
-                <td>Will return content of the form 'I don't give a flying fuck. - :from'. </td>
+                <td>Will return content of the form 'I don't give a flying fuck. - :from'. e.g. <a href='/flying/batman' target='_blank'>/flying/batman</a> </td>
             </tr>
 
             <tr>
@@ -189,12 +190,12 @@
                 <td>/because/:from</td>
                 <td>Will return content of the form 'Why? Because Fuck you, that's why. - :from'. </td>
             </tr>
-            
+
             <tr>
                 <td>/caniuse/:tool/:from</td>
                 <td>Will return content of the form 'Can you use :tool? Fuck no! - :from'.</td>
             </tr>
-            
+
             <tr>
                 <td>/bye/:from</td>
                 <td>Will return content of the form 'Fuckity bye! - :from'.</td>
@@ -217,11 +218,11 @@
 
             <tr>
                 <td>/awesome/:from</td>
-                <td>Will return content of the form 'This is Fucking Awesome. - :from', , e.g. /awesome/Macklemore will return 'This is Fucking Awesome. - Macklemore'</td>
+                <td>Will return content of the form 'This is Fucking Awesome. - :from', , e.g. <a href='/awesome/Macklemore' target='_blank'>/awesome/Macklemore</a> will return 'This is Fucking Awesome. - Macklemore'</td>
             </tr>
             <tr>
                 <td>/tucker/:from</td>
-                <td>Will return content of the form 'Come the fuck in or fuck the fuck off. - :from', e.g. /tucker/Malcolm+Tucker will return 'Come the fuck in or fuck the fuck off. - Malcolm Tucker'</td>
+                <td>Will return content of the form 'Come the fuck in or fuck the fuck off. - :from', e.g. <a href='/tucker/Malcolm+Tucker' target='_blank'>/tucker/Malcolm+Tucker</a> will return 'Come the fuck in or fuck the fuck off. - Malcolm Tucker'</td>
             </tr>
             <tr>
                 <td>/bucket/:from</td>
@@ -252,7 +253,7 @@
         </p>
             Filters can be used in combinations, e.g. <a href="http://foaas.com/off/Tom/Everyone?shoutcloud&i18n=de">http://foaas.com/off/Tom/Everyone?<em>shoutcloud&amp;i18n=de</em></a>
         </p>
-        
+
         <h2 id="roadmap">Roadmap</h2>
 
         <p>FOASS will be extended to include the following functionality:</p>


### PR DESCRIPTION
I love the examples that succinctly exemplify how to tell some to F* off. This PR makes those example links in the description clickable so people can readily experience the joy of the service with a single click.