### PR TITLE
Update README.md, Add Java API

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ API clients are available in a number of languages:
 | R        | `rfoaas`       | https://github.com/eddelbuettel/rfoaas |
 | CLI/bash | `foaas.sh`     | https://github.com/RaymiiOrg/foaas.sh |
 | .NET     | `FOAASClient`  | https://github.com/igorkulman/FOAASClient |
+| Java     | `JFOAAS`       | https://github.com/AnUnknownMiner/FOAAS-Java |
 
 # Integrate FOAAS
 


### PR DESCRIPTION
This PR adds my in development API of FOAAS for Java to the list of available APIs.