### PR TITLE
Added dosomething resource (:do the fucking :something! - :from)

### DIFF
--- a/lib/operations/dosomething.coffee
+++ b/lib/operations/dosomething.coffee
@@ -1,0 +1,14 @@
+module.exports =
+	name: "Do Something"
+	url: '/dosomething/:do/:something/:from'
+	fields: [
+		{ name: 'Do', field: 'do'}
+		{ name: 'Something', field: 'something'}
+		{ name: 'From', field: 'from'}
+	]
+
+	register: (app, output) ->
+		app.get '/dosomething/:do/:something/:from', (req, res) ->
+			message = "#{req.params.do} the fucking #{req.params.something}!"
+			subtitle = "- #{req.params.from}"
+			output(req, res, message, subtitle)

--- a/public/index.html
+++ b/public/index.html
@@ -245,6 +245,11 @@
                 <td>/zayn/:from</td>
                 <td>Will return content of the form 'Ask me if I give a motherfuck ?!! - :from'.</td>
             </tr>
+
+            <tr>
+                <td>/dosomething/:do/:something/:from</td>
+                <td>Will return content of the form ':do the fucking :something! - :from'.</td>
+            </tr>
         </table>
 
         <h3 id="filters">Filters</h2>

--- a/spec/operations/dosomething.coffee
+++ b/spec/operations/dosomething.coffee
@@ -1,0 +1,44 @@
+operation = require '../../lib/operations/dosomething'
+
+describe "/dosomething", ->
+  it "should have the correct name", ->
+    expect(operation.name).toEqual('Do Something')
+
+  it "should have the correct url", ->
+    expect(operation.url).toEqual('/dosomething/:do/:something/:from')
+
+  it "should have the correct fields", ->
+    expect(operation.fields).toEqual([
+		{ name: 'Do', field: 'do'}
+		{ name: 'Something', field: 'something'}
+		{ name: 'From', field: 'from'}
+    ])
+
+  describe 'register', ->
+    it 'should call app.get with correct url', ->
+      app =
+        get: jasmine.createSpy()
+
+      operation.register(app,null)
+
+      expect(app.get).toHaveBeenCalled()
+      expect(app.get.argsForCall[0][0]).toEqual('/dosomething/:do/:something/:from')
+
+    it 'should call output with correct params', ->
+      func = null
+      app =
+        get: (url, fn) -> func = fn
+      output = jasmine.createSpy()
+      operation.register(app, output)
+
+      req = 
+        params:
+          do: "TESTACTION"
+          something: "TESTITEM"
+          from: "TESTFROM"
+
+      message = "#{req.params.do} the fucking #{req.params.something}!"
+      subtitle = "- #{req.params.from}"
+
+      func(req,'RES')
+      expect(output).toHaveBeenCalledWith(req, 'RES', message, subtitle)


### PR DESCRIPTION
Can either be used in the "classic" way: `/dosomething/Commit/code/Matthias`
"`Commit` the fucking `code`! – `Matthias`" … 

… or "extended": `/dosomething/Arnold, get to/choppa/Matthias`
"`Arnold, get to` the fucking `choppa`! – `Matthias`"