### PR TITLE
Added keepcalm resource (Keep the fuck calm and :reaction! - :from)

### DIFF
--- a/lib/operations/keepcalm.coffee
+++ b/lib/operations/keepcalm.coffee
@@ -1,0 +1,13 @@
+module.exports =
+	name: "Keep Calm"
+	url: '/keepcalm/:reaction/:from'
+	fields: [
+		{ name: 'Reaction', field: 'reaction'}
+		{ name: 'From', field: 'from'}
+	]
+
+	register: (app, output) ->
+		app.get '/keepcalm/:reaction/:from', (req, res) ->
+			message = "Keep the fuck calm and #{req.params.reaction}!"
+			subtitle = "- #{req.params.from}"
+			output(req, res, message, subtitle)

--- a/public/index.html
+++ b/public/index.html
@@ -245,6 +245,11 @@
                 <td>/zayn/:from</td>
                 <td>Will return content of the form 'Ask me if I give a motherfuck ?!! - :from'.</td>
             </tr>
+
+            <tr>
+                <td>/keepcalm/:reaction/:from</td>
+                <td>Will return content of the form 'Keep the fuck calm and :reaction! - :from'.</td>
+            </tr>
         </table>
 
         <h3 id="filters">Filters</h2>

--- a/spec/operations/keepcalm.coffee
+++ b/spec/operations/keepcalm.coffee
@@ -1,0 +1,42 @@
+operation = require '../../lib/operations/keepcalm'
+
+describe "/keepcalm", ->
+	it "should have the correct name", ->
+		expect(operation.name).toEqual('Keep Calm')
+
+	it "should have the correct url", ->
+		expect(operation.url).toEqual('/keepcalm/:reaction/:from')
+
+	it "should have the correct fields", ->
+		expect(operation.fields).toEqual([
+			{ name: 'Reaction', field: 'reaction'}
+			{ name: 'From', field: 'from'}
+		])
+
+	describe 'register', ->
+		it 'should call app.get with correct url', ->
+			app =
+				get: jasmine.createSpy()
+
+			operation.register(app,null)
+
+			expect(app.get).toHaveBeenCalled()
+			expect(app.get.argsForCall[0][0]).toEqual('/keepcalm/:reaction/:from')
+
+		it 'should call output with correct params', ->
+			func = null
+			app =
+				get: (url, fn) -> func = fn
+			output = jasmine.createSpy()
+			operation.register(app, output)
+
+			req =
+				params:
+					reaction: "TESTREACTION"
+					from: "TESTFROM"
+
+			message = "Keep the fuck calm and #{req.params.reaction}!"
+			subtitle = "- #{req.params.from}"
+
+			func(req,'RES')
+			expect(output).toHaveBeenCalledWith(req, 'RES', message, subtitle)


### PR DESCRIPTION
Can either be used in the "classic" way: `/keepcalm/code on/Matthias`
"Keep the fuck calm and `code on`! – `Matthias`" …

… or with a little more fantasy: `/keepcalm/chill the fuck out/Matthias`
"Keep the fuck calm and `chill the fuck out`! – `Matthias`" 