### PR TITLE
Pinned i18next

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "newrelic": "latest",
     "xml-escape": "latest",
     "request": "latest",
-    "i18next": "latest",
+    "i18next": "1.10.6",
     "md5": "latest",
     "underscore": "latest",
     "method-override": "latest"


### PR DESCRIPTION
More recent versions prevents npm starting:

ubuntu@surge:~/FOAAS/GITPUSH/foaas$ npm start

> foaas@0.1.8 start /home/ubuntu/FOAAS/GITPUSH/foaas
> ./node_modules/.bin/coffee lib/server.coffee

TypeError: app.use() requires middleware functions
  at EventEmitter.use (/home/ubuntu/FOAAS/GITPUSH/foaas/node_modules/express/lib/application.js:209:11)
  at EventEmitter.wrappedAppUse [as use] (/home/ubuntu/FOAAS/GITPUSH/foaas/node_modules/newrelic/lib/instrumentation/express.js:348:11)
  at Object.module.exports.register (/home/ubuntu/FOAAS/GITPUSH/foaas/lib/filters/i18n.coffee:17:9)
  at FOAAS.module.exports.FOAAS.loadFilters (/home/ubuntu/FOAAS/GITPUSH/foaas/lib/foaas.coffee:90:14)
  at FOAAS.loadFilters (/home/ubuntu/FOAAS/GITPUSH/foaas/lib/foaas.coffee:1:1)
  at new FOAAS (/home/ubuntu/FOAAS/GITPUSH/foaas/lib/foaas.coffee:42:6)
  at Object.<anonymous> (/home/ubuntu/FOAAS/GITPUSH/foaas/lib/server.coffee:6:13)
  at Object.<anonymous> (/home/ubuntu/FOAAS/GITPUSH/foaas/lib/server.coffee:1:1)
  at Module._compile (module.js:456:26)

npm ERR! weird error 1
npm WARN This failure might be due to the use of legacy binary "node"
npm WARN For further explanations, please read
/usr/share/doc/nodejs/README.Debian
 
npm ERR! not ok code 0