### PR TITLE
Ability to tell someone to 'Fucking fuck off' by use of a 'Fucking' adverb

### DIFF
--- a/lib/operations/ing.coffee
+++ b/lib/operations/ing.coffee
@@ -1,0 +1,13 @@
+module.exports =
+  name: "Fucking"
+  url: '/ing/:name/:from'
+  fields: [
+    { name: 'Name', field: 'name'}
+    { name: 'From', field: 'from'}
+  ]
+
+  register: (app, output) ->
+    app.get '/ing/:name/:from', (req, res) ->
+      message = "Fucking fuck off, #{req.params.name}."
+      subtitle = "- #{req.params.from}"
+      output(req, res, message, subtitle)

--- a/public/index.html
+++ b/public/index.html
@@ -4,7 +4,7 @@
     <title>Fuck Off As A Service (FOAAS)</title>
 
     <link href="//netdna.bootstrapcdn.com/twitter-bootstrap/2.3.2/css/bootstrap-combined.min.css" rel="stylesheet">
-    
+
     <meta name="twitter:card" content="summary">
     <meta name="twitter:site" content="@foaas">
     <meta name="twitter:creator" content="@TomDionysus">
@@ -64,6 +64,11 @@
             <tr>
                 <td>/off/:name/:from</td>
                 <td>Will return content of the form 'Fuck off, :name. - :from', e.g. <a href='/off/Tom/Chris' target='_blank'>/off/Tom/Chris</a> will return 'Fuck off, Tom - Chris'</td>
+            </tr>
+
+            <tr>
+                <td>/ing/:name/:from</td>
+                <td>Will return content of the form 'Fucking fuck off, :name. - :from', e.g. <a href='/ing/Tom/Chris' target='_blank'>/ing/Tom/Chris</a> will return 'Fucking fuck off, Tom - Chris'</td>
             </tr>
 
             <tr>
@@ -337,12 +342,12 @@
                 <td>/zero/:from</td>
                 <td>Zero, thats the number of fucks I give. - :from".</td>
             </tr>
-            
+
             <tr>
                 <td>/pulp/:language/:from</td>
                 <td>Will return content of the form ":language, motherfucker, do you speak it? - :from".</td>
             </tr>
-            
+
             <tr>
                 <td>/sake/:from</td>
                 <td>Will return content of the form "For Fuck's sake! - :from".</td>

--- a/spec/operations/ing_spec.coffee
+++ b/spec/operations/ing_spec.coffee
@@ -1,0 +1,44 @@
+operation = require '../../lib/operations/ing'
+
+describe "/ing", ->
+  it "should have the correct name", ->
+    expect(operation.name).toEqual('Fucking')
+
+  it "should have the correct url", ->
+    expect(operation.url).toEqual('/ing/:name/:from')
+
+  it "should have the correct fields", ->
+    expect(operation.fields).toEqual([
+      { name: 'Name', field: 'name'}
+      { name: 'From', field: 'from'}
+    ])
+
+  describe 'register', ->
+    it 'should call app.get with correct url', ->
+      app =
+        get: jasmine.createSpy()
+
+      operation.register(app,null)
+
+      expect(app.get).toHaveBeenCalled()
+      expect(app.get.argsForCall[0][0]).toEqual('/ing/:name/:from')
+
+    it 'should call output with correct params', ->
+      func = null
+      app =
+        get: (url, fn) -> func = fn
+      output = jasmine.createSpy()
+      operation.register(app, output)
+
+      req =
+        params:
+          name: "TESTNAME"
+          from: "TESTFROM"
+
+      func(req,'RES')
+      expect(output).toHaveBeenCalledWith(
+        req,
+        'RES',
+        'Fucking fuck off, TESTNAME.',
+        '- TESTFROM'
+      )


### PR DESCRIPTION
Its important to be able to place more emphasis in a simple and adverbial way when telling someone to fuck off. In some parts of the world telling someone to 'Fucking fuck off' provides more than reasonable urgency in needing to fuck off promptly.