### PR TITLE
Renames fields keys

### DIFF
--- a/lib/operations/greed.coffee
+++ b/lib/operations/greed.coffee
@@ -2,8 +2,8 @@ module.exports =
   name: "Greed"
   url: '/greed/:noun/:from'
   fields: [
-    { noun: 'Noun', field: 'noun'}
-    { from: 'From', field: 'from'}
+    { name: 'Noun', field: 'noun'}
+    { name: 'From', field: 'from'}
   ]
 
   register: (app, output) ->

--- a/spec/operations/greed_spec.coffee
+++ b/spec/operations/greed_spec.coffee
@@ -9,8 +9,8 @@ describe "/greed", ->
 
   it "should have the correct fields", ->
     expect(operation.fields).toEqual([
-      { noun: 'Noun', field: 'noun'}
-      { from: 'From', field: 'from'}
+      { name: 'Noun', field: 'noun'}
+      { name: 'From', field: 'from'}
     ])
 
   describe 'register', ->


### PR DESCRIPTION
Renames the `fields` keys in `Greed` operation to match the rest of the foaas operations. 

Currently, the `Greed` is the only operation which doesn't return its `fields` with `name` and `field` as  keys (besides `Version`).