### PR TITLE
The old link was 404d

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,6 @@ API clients are available in a number of languages:
 
 | Platform/Software     | Name                                                                         |
 |:----------------------|:-----------------------------------------------------------------------------|
-| Hubot				    | https://github.com/github/hubot-scripts/blob/master/src/scripts/FOAAS.coffee |
 | Thunderbird/Seamonkey | https://addons.mozilla.org/en-US/seamonkey/addon/qfo-quick-fuck-off          |
 | TelegramBot           | https://github.com/rajanand02/TelegramFoaasBot                               |
 | Slack                 | https://github.com/revmischa/foaas-slack                                     |


### PR DESCRIPTION
Removed to prevent confusion