### PR TITLE
[ISSUE-199] i18n.js: bugfix. Support special chars

### DIFF
--- a/lib/filters/i18n.js
+++ b/lib/filters/i18n.js
@@ -35,24 +35,23 @@ module.exports = {
     if (lang === '') { lang = req.locale; }
     if (lang === '') { lang = 'en'; }
 
-    const separator = '!!,.,!!';
+    const separator = '␤';
     // Shortcut if already english.
     if (lang === 'en') { return next(req, res); }
 
     const key = md5(lang+req.message+req.subtitle);
 
     if (module.exports.cache[key] != null) {
-      const txtt = module.exports.cache[key].split(separator);
-      //console.log txtt
-      req.message = txtt[0];
-      req.subtitle = txtt[1];
+      const cached = module.exports.cache[key].split(separator);
+      req.message = cached[0];
+      req.subtitle = cached[1];
       return next(req, res);
     } else {
       const txt = `${req.message} ${separator} ${req.subtitle}`;
-      return request.post({
-        headers: { 'content-type': 'application/json'
-      },
-        url: `http://api.mymemory.translated.net/get?q=${txt}&langpair=en|${lang}`
+      return request.get({
+        headers: { 'content-type': 'application/json' },
+        url: 'http://api.mymemory.translated.net/get',
+        qs: { q: txt, langpair: `en|${lang}` }
       }, (error, response, body) => {
         if (error != null) { return module.exports.onError(req, res); }
         try {


### PR DESCRIPTION
This commit arranges the issue #199 which was causing translation
issues.
Remote service call has been migrated to GET method, and separator has
been changed for a single non-common char.

The main issue behind the bug was the URL query-string scaping. Now the
query-string is built using the provided method by the request
library