### PR TITLE
Added link to Terraform provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ API clients are available in a number of languages:
 | TelegramBot                                 | https://github.com/rajanand02/TelegramFoaasBot                               |
 | Slack                                       | https://github.com/revmischa/foaas-slack                                     |
 | Amazon Echo                                 | https://www.amazon.com/dp/B01LZLFTMQ/ (source available [here](https://github.com/martinschaef/foaas-alex))|
+| Terraform Provider                          | https://github.com/m13t/terraform-provider-foac                              |
 
 # Contributing
 


### PR DESCRIPTION
Hi!

I've created a provider plugin for Terraform to provide the available REST routes as data sources.

https://github.com/m13t/terraform-provider-foac