### PR TITLE
Add my web client in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,13 @@ API clients are available in a number of languages:
 | Crystal  | `foaas_client` | https://github.com/mamantoha/foaas_client      |
 | Rust     | `foaas-rs`     | https://github.com/jilsahm/foaas-rs            |
 
+# GUI Clients
+
+| Platform          | Info                                                    |
+|:------------------|:--------------------------------------------------------|
+| Web               | https://github.com/hamza1311/fuck-off                   |
+
+
 # Framework Support
 
 | Framework     | Info                                                                         |


### PR DESCRIPTION
This includes my web client in the README. I've added a new section for GUI clients.  
Hosted at: https://hamza1311.github.io/fuck-off/ 

Let me know if there's anything that needs to be changed.